### PR TITLE
Quick fix on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install react-phone-input-material-ui --save
 
 or
 
-yarn install react-phone-input-material-ui
+yarn add react-phone-input-material-ui
 ```
 
 ## Usage with Material UI


### PR DESCRIPTION
Quick fix on README.md for install react-phone-input-mui with yarn.

`yarn install react-phone-input-material-ui` => `yarn add react-phone-input-material-ui`