### PR TITLE
Allow for react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.10",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "@material-ui/core": ">=4.9.10",
+    "react": ">=16.12.0",
+    "react-dom": ">=16.12.0"
   }
 }


### PR DESCRIPTION
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: my-app@0.1.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR!   peer react@"^16.8.0 || ^17.0.0" from @material-ui/core@4.11.4
npm ERR!   node_modules/@material-ui/core
npm ERR!     @material-ui/core@"^4.11.2" from the root project
npm ERR!     peer @material-ui/core@"^4.9.10" from react-phone-input-material-ui@2.15.1
npm ERR!     node_modules/react-phone-input-material-ui
npm ERR!       react-phone-input-material-ui@"^2.15.1" from the root project
npm ERR!   1 more (react-dom)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.12.0" from react-phone-input-material-ui@2.15.1
npm ERR! node_modules/react-phone-input-material-ui
npm ERR!   react-phone-input-material-ui@"^2.15.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See C:\Users\alice\AppData\Local\npm-cache\eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\alice\AppData\Local\npm-cache\_logs\2021-06-03T17_23_25_068Z-debug.log
```