### PR TITLE
fix: don't crash if doubleClick event target lacks value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -638,8 +638,10 @@ class PhoneInput extends React.Component {
   };
 
   handleDoubleClick = (e) => {
-    const len = e.target.value.length;
-    e.target.setSelectionRange(0, len);
+    if (e.target.value) {
+      const len = e.target.value.length;
+      e.target.setSelectionRange(0, len);
+    }
   };
 
   handleFlagItemClick = (country, e) => {


### PR DESCRIPTION
Refs: #17