### PR TITLE
fix: allow react 18 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "@emotion/styled": "^11.6.0",
     "@material-ui/core": "^4.12.3",
     "@mui/material": "^5.4.1",
-    "react": "^16.12.0 || ^17.0.0",
-    "react-dom": "^16.12.0 || ^17.0.0"
+    "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@material-ui/core": {


### PR DESCRIPTION
It seems that there ain't any particular issues just running this on react 18.

Refs: #13