### PR TITLE
fix: rename typescript's `specialLabel` to `label`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,7 +104,7 @@ declare module "react-phone-input-material-ui" {
     showDropdown?: boolean;
 
     defaultErrorMessage?: string;
-    specialLabel?: string;
+    label?: string;
     disableInitialCountryGuess?: boolean;
     disableCountryGuess?: boolean;
   }


### PR DESCRIPTION
This prop has the name `label` in js props.

Refs: #20